### PR TITLE
Update README.md: link to binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ https://camo.githubusercontent.com/915b7be44ada53c290eb157634330494ebe3e30a/6874
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/ubiq/go-ubiq?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 Automated builds are available for stable releases and the unstable master branch.
-Binary archives are published at https://gubiq.ethereum.org/downloads/.
+Binary archives are published at https://github.com/ubiq/go-ubiq/releases.
 
 ## Building the source
 


### PR DESCRIPTION
The link to project binaries that points to ubiq subdomain within ethereum.org is broken. Suggesting to point instead to the local repo.